### PR TITLE
Verificación directorio

### DIFF
--- a/Infrastructure/logging/logger.ts
+++ b/Infrastructure/logging/logger.ts
@@ -1,4 +1,11 @@
+import fs from 'fs';
+import path from 'path';
 import winston from 'winston';
+
+const logDir = path.resolve('logs');
+if (!fs.existsSync(logDir)) {
+  fs.mkdirSync(logDir);
+}
 
 const logger = winston.createLogger({//TO DO: Add label to Log in a loggerCreator
   level: 'info',
@@ -10,8 +17,8 @@ const logger = winston.createLogger({//TO DO: Add label to Log in a loggerCreato
   ),
   transports: [
     new winston.transports.Console(),
-    new winston.transports.File({ filename: 'logs/error.log', level: 'error' }),
-    new winston.transports.File({ filename: 'logs/combined.log' })
+    new winston.transports.File({ filename: path.join(logDir, 'error.log'), level: 'error' }),
+    new winston.transports.File({ filename: path.join(logDir, 'combined.log') })
   ]
 });
 

--- a/Infrastructure/logging/logger.ts
+++ b/Infrastructure/logging/logger.ts
@@ -3,10 +3,16 @@ import path from 'path';
 import winston from 'winston';
 
 const logDir = path.resolve('logs');
-if (!fs.existsSync(logDir)) {
-  fs.mkdirSync(logDir);
-}
 
+try{
+  if (!fs.existsSync(logDir)) {
+    fs.mkdirSync(logDir);
+  }
+}catch (error){
+  console.error(`No se pudo crear el directorio de logs en ${logDir}:`, error);
+  await new Promise(resolve => setTimeout(resolve, 100));
+  process.exit(1);
+}
 const logger = winston.createLogger({//TO DO: Add label to Log in a loggerCreator
   level: 'info',
   format: winston.format.combine(


### PR DESCRIPTION
Se verifica la existencia del directorio logs al iniciar el logger. Si no existe, se crea automáticamente para evitar errores al escribir archivos de log.