### PR TITLE
Update release workflow for manual triggering and draft releases

### DIFF
--- a/.github/workflows/releasing.yml
+++ b/.github/workflows/releasing.yml
@@ -1,14 +1,20 @@
-name: Build on Release
+name: Build and Draft Release
 
 on:
-  release:
-    types: [prereleased, released]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name (ej: v1.2.3)'
+        required: true
+
+permissions:
+  contents: write
 
 jobs:
   run_tests:
     uses: ./.github/workflows/testing.yml
 
-  build:
+  build_and_release:
     needs: run_tests
     runs-on: ubuntu-latest
     steps:
@@ -28,10 +34,12 @@ jobs:
       - name: Compress build folder
         run: zip -r build-output.zip dist # Comprime la carpeta de salida
 
-      - name: Upload Release Asset
+      - name: Create Draft Release and Upload Asset
         uses: softprops/action-gh-release@v2
         with:
-          files: build-output.zip # Sube el archivo comprimido como asset del release
+          tag_name: ${{ github.event.inputs.tag_name }}
+          draft: true
+          files: build-output.zip
         env:
 
           # Este valor utiliza el token de autenticación proporcionado automáticamente por GitHub Actions a través del workspace.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,30 @@ Los logs de eventos e errores se guardan en la carpeta `/logs`. Se rotan automá
 
 ---
 
+## 📦 Publicación de Releases
+
+Para asegurar que los _builds_ se generen y publiquen correctamente junto con sus respectivos assets (como el ZIP del build), **las releases deben crearse directamente desde GitHub**. Esto dispara el workflow definido en el archivo [`.github/workflows/releasing.yml`](.github/workflows/releasing.yml).
+
+### Cómo Funciona el Release Workflow
+
+1. **Creación de la Release**  
+   - Cuando creas una nueva release en GitHub (usando un tag único que no exista previamente), el workflow se dispara automáticamente.
+   - **Importante:** El tag debe ser único, ya que si ya existe una release con ese tag GitHub tratará de actualizarla y podría generar errores de permisos.
+
+2. **Ejecución del Workflow**  
+   El workflow `releasing.yml` realizará los siguientes pasos:
+   - Ejecutará los tests definidos en el workflow de testing.
+   - Compilará el proyecto y comprimirá la carpeta de salida (por ejemplo, `dist`) en un archivo ZIP.
+   - Creará la release en modo _draft_ (borrador), subirá el asset generado y, finalmente, publicará la release mediante una actualización de la misma.
+
+3. **Recomendación**  
+   - Siempre crea la release desde la interfaz de GitHub o mediante la CLI (por ejemplo, usando `gh release create`) **con un tag nuevo**.
+   - De esta forma, el workflow se encargará de generar el _build_ y adjuntarlo automáticamente a la release.
+
+Con este proceso, aseguras que cada release se publique con el _build_ actualizado sin errores de permisos ni conflictos al intentar modificar una release ya existente.
+
+---
+
 ## 🌱 Flujo de trabajo con Git
 
 Usamos **GitFlow**:


### PR DESCRIPTION
Enhance the release workflow to support manual triggering and create draft releases. This change ensures builds are generated and published correctly with their respective assets.